### PR TITLE
fix: broken registration page

### DIFF
--- a/src/main/java/io/gatling/demostore/website/controllers/RegistrationController.java
+++ b/src/main/java/io/gatling/demostore/website/controllers/RegistrationController.java
@@ -2,11 +2,8 @@ package io.gatling.demostore.website.controllers;
 
 import javax.validation.Valid;
 
-import io.gatling.demostore.models.UserRepository;
 import io.gatling.demostore.models.data.User;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -19,7 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class RegistrationController {
 
     @GetMapping
-    public String register() {
+    public String register(Model model) {
+        model.addAttribute("user", new User());
         return "register";
     }
 


### PR DESCRIPTION
Motivation:

Registration page is broken because the 'user' object is not initialized to an empty user when showing the form.

Modifications:

Properly initialize the  'user' object when showing the registration form.

Result:

The form works (note: the form doesn't actually create new users, as expected).