### PR TITLE
chore: Use our distroless base image instead of Ubuntu-based image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-target/
-Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,13 +35,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
+          cache: 'maven'
 
-      - name: Cache Maven
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+      - name: Build Maven
+        run: mvn --batch-mode clean package
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'
@@ -66,7 +63,7 @@ jobs:
           docker build \
             --tag ${ECR_REGISTRY:-dummy}/$ECR_REPOSITORY:$IMAGE_VERSION \
             --file Dockerfile \
-            .
+            ./target
 
       - name: Docker push
         if: github.ref == 'refs/heads/main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,20 @@
-FROM maven:3-openjdk-17 AS builder
+FROM gatlingcorp/openjdk-base:17-jre-headless AS builder
 
-COPY ./pom.xml /build/pom.xml
+COPY ./demo-store-*.jar /app/demo-store.jar
 
-WORKDIR /build
-
-RUN mvn --batch-mode dependency:resolve
-
-COPY . /build
-
-RUN mvn --batch-mode clean package
-
-RUN chmod -R g=u /build/target/demo-store-*.jar
+# Doing this modifies a lot of files, duplicating the content of /app in two layers: COPY above and RUN below,
+# hence the builder image.
+RUN chmod -R g=u /app
 
 FROM gatlingcorp/openjdk-base:17-jre-headless
 LABEL gatling="demostore"
 
-COPY --from=builder --chown=1001:0 /build/target/demo-store-*.jar /app/demo-store.jar
+COPY --from=builder --chown=1001:0 /app /app
 
 WORKDIR /app
 ENV HOME=/app
 USER 1001
 
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "./demo-store.jar"]
+ENTRYPOINT ["java", "-jar", "/app/demo-store.jar"]
 CMD []


### PR DESCRIPTION
Motivation:

- Reduce image size
- Reduce unnecessary dependencies in the image (reduce attack surface)

Modifications:

Build the demo store Docker image from our distroless base image (gatlingcorp/openjdk-base) rather than from Zulu's Ubuntu-based image (azul/zulu-openjdk).